### PR TITLE
Added a way to manually run the loop

### DIFF
--- a/libasync/src/async/event/selector.d
+++ b/libasync/src/async/event/selector.d
@@ -53,6 +53,27 @@ abstract class Selector
     bool reregister(const int fd, EventType et);
     bool unregister(const int fd);
 
+    void initialize()
+    {
+        version (Windows)
+        {
+            foreach (i; 0 .. _workerThreadNum)
+                workerPool.run!handleEvent(this);
+        }
+    }
+    
+    void runLoop()
+    {
+        version (Windows)
+        {
+            beginAccept(this);
+        }
+        else
+        {
+            handleEvent();
+        }
+    }
+    
     void startLoop()
     {
         _runing = true;


### PR DESCRIPTION
Sometimes don't want to block thread, so i have added a way to manually run the loop

Maybe that is not necessary, or could be done by extending the class, but i felt like it could be nice to have that option out of the box

But i can understand if don't want to change it